### PR TITLE
chore: upgrade esbuild-loader to v2.11.0

### DIFF
--- a/examples/basic-setup/package.json
+++ b/examples/basic-setup/package.json
@@ -6,7 +6,7 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "esbuild-loader": "^2.10.0",
+    "esbuild-loader": "^2.11.0",
     "webpack": "^5.24.2",
     "webpack-cli": "^4.5.0"
   }

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -12,7 +12,7 @@
 		"react-dom": "17.0.1"
 	},
 	"devDependencies": {
-		"esbuild-loader": "^2.10.0",
+		"esbuild-loader": "^2.11.0",
 		"webpack": "^5.24.2"
 	}
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -10,7 +10,7 @@
 		"react-dom": "^17.0.1"
 	},
 	"devDependencies": {
-		"esbuild-loader": "^2.10.0",
+		"esbuild-loader": "^2.11.0",
 		"html-webpack-plugin": "^5.2.0",
 		"serv": "^0.2.4",
 		"typescript": "^4.2.2",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -7,7 +7,7 @@
     "build": "npm run typecheck && webpack"
   },
   "devDependencies": {
-    "esbuild-loader": "^2.10.0",
+    "esbuild-loader": "^2.11.0",
     "typescript": "^4.2.2",
     "webpack": "^5.24.2",
     "webpack-cli": "^4.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,11 @@ importers:
       husky: ^4.3.8
   examples/basic-setup:
     devDependencies:
-      esbuild-loader: 2.10.0_webpack@5.24.2
+      esbuild-loader: 2.11.0_webpack@5.24.2
       webpack: 5.24.2_webpack-cli@4.5.0
       webpack-cli: 4.5.0_webpack@5.24.2
     specifiers:
-      esbuild-loader: ^2.10.0
+      esbuild-loader: ^2.11.0
       webpack: ^5.24.2
       webpack-cli: ^4.5.0
   examples/next:
@@ -21,10 +21,10 @@ importers:
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
     devDependencies:
-      esbuild-loader: 2.10.0_webpack@5.24.2
+      esbuild-loader: 2.11.0_webpack@5.24.2
       webpack: 5.24.2
     specifiers:
-      esbuild-loader: ^2.10.0
+      esbuild-loader: ^2.11.0
       next: 10.0.7
       react: 17.0.1
       react-dom: 17.0.1
@@ -34,14 +34,14 @@ importers:
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
     devDependencies:
-      esbuild-loader: 2.10.0_webpack@5.24.2
+      esbuild-loader: 2.11.0_webpack@5.24.2
       html-webpack-plugin: 5.2.0_webpack@5.24.2
       serv: 0.2.4
       typescript: 4.2.2
       webpack: 5.24.2_webpack-cli@4.5.0
       webpack-cli: 4.5.0_webpack@5.24.2
     specifiers:
-      esbuild-loader: ^2.10.0
+      esbuild-loader: ^2.11.0
       html-webpack-plugin: ^5.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
@@ -51,12 +51,12 @@ importers:
       webpack-cli: ^4.5.0
   examples/typescript:
     devDependencies:
-      esbuild-loader: 2.10.0_webpack@5.24.2
+      esbuild-loader: 2.11.0_webpack@5.24.2
       typescript: 4.2.2
       webpack: 5.24.2_webpack-cli@4.5.0
       webpack-cli: 4.5.0_webpack@5.24.2
     specifiers:
-      esbuild-loader: ^2.10.0
+      esbuild-loader: ^2.11.0
       typescript: ^4.2.2
       webpack: ^5.24.2
       webpack-cli: ^4.5.0
@@ -1125,26 +1125,26 @@ packages:
     dev: true
     resolution:
       integrity: sha512-iuEGihqqhKWFgh72Q/Jtch7V2t/ft8w8IPP2aEN8ArYKO+IWyo6hsi96hCdgyeEDQIV3InhYQ9BlwUFPGXrbEQ==
-  /esbuild-loader/2.10.0_webpack@5.24.2:
+  /esbuild-loader/2.11.0_webpack@5.24.2:
     dependencies:
-      esbuild: 0.9.2
-      joycon: 2.2.5
+      esbuild: 0.10.2
+      joycon: 3.0.1
       json5: 2.2.0
       loader-utils: 2.0.0
-      type-fest: 0.21.3
+      type-fest: 1.0.1
       webpack: 5.24.2_webpack-cli@4.5.0
       webpack-sources: 2.2.0
     dev: true
     peerDependencies:
       webpack: ^4.40.0 || ^5.0.0
     resolution:
-      integrity: sha512-BRWmc/7gU6/FmI+MP+E+9Zb/CE0BA1XMOQkdvJ7B/T2gad1Mlim8aMhvvRdS9on5S8JzkC+uNHGQmt/WmbbXbQ==
-  /esbuild/0.9.2:
+      integrity: sha512-yFzrpIvhHRtV1Z8V1VtW6xm0dmEHlBheJjhx+EJPTcSKBhVMeIKC2FVyZ+N1ZgSBZEKgky9vtD4q455HgnT/3g==
+  /esbuild/0.10.2:
     dev: true
     hasBin: true
     requiresBuild: true
     resolution:
-      integrity: sha512-xE3oOILjnmN8PSjkG3lT9NBbd1DbxNqolJ5qNyrLhDWsFef3yTp/KTQz1C/x7BYFKbtrr9foYtKA6KA1zuNAUQ==
+      integrity: sha512-/5vsZD7wTJJHC3yNXLUjXNvUDwqwNoIMvFvLd9tcDQ9el5l13pspYm3yufavjIeYvNtAbo+6N/6uoWx9dGA6ug==
   /escalade/3.1.1:
     engines:
       node: '>=6'
@@ -1655,12 +1655,12 @@ packages:
       node: '>= 10.13.0'
     resolution:
       integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
-  /joycon/2.2.5:
+  /joycon/3.0.1:
     dev: true
     engines:
-      node: '>=6'
+      node: '>=10'
     resolution:
-      integrity: sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==
+      integrity: sha512-SJcJNBg32dGgxhPtM0wQqxqV0ax9k/9TaUskGDSJkSFSQOEWWvQ3zzWdGQRIUry2j1zA5+ReH13t0Mf3StuVZA==
   /js-tokens/4.0.0:
     resolution:
       integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3025,18 +3025,18 @@ packages:
     optional: true
     resolution:
       integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
-  /type-fest/0.21.3:
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
   /type-fest/0.7.1:
     dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
+  /type-fest/1.0.1:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-+UTPE7JT3O+sUpRroRgQAbbSfIRBwOHh+o/oruB1JJE6g6uBm3Y0D82fO3xu8VHfxJLQjeRp0PEY6mRmh/lElA==
   /typescript/4.2.2:
     dev: true
     engines:


### PR DESCRIPTION
### Before
```
➜  esbuild-loader-examples git:(master) pnpm run build -r
Scope: all 5 workspace projects
examples/basic-setup build$ webpack
│ asset main.js 1.24 KiB [emitted] [minimized] (name: main)
│ ./src/index.js 2.34 KiB [built] [code generated]
│ webpack 5.24.2 compiled successfully in 394 ms
└─ Done in 1.6s
examples/next build$ next build
[13 lines collapsed]
│   ├ chunks/commons.65666e.js                                   2.83 kB
│   ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.15ed73.js  9.33 kB
│   ├ chunks/main.9db440.js                                      45.8 kB
│   ├ chunks/pages/_app.32fed5.js                                310 B
│   ├ chunks/webpack.0f0fcd.js                                   760 B
│   └ css/6e9ef204d6fd7ac61493.css                               194 B
│ λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
│ ○  (Static)  automatically rendered as static HTML (uses no initial props)
│ ●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
│    (ISR)     incremental static regeneration (uses revalidate in getStaticProps)
└─ Done in 4.1s
examples/react build$ webpack
[6 lines collapsed]
│     ../../node_modules/.pnpm/react-dom@17.0.1_react@17.0.1/node_modules/react-dom/cjs/react-dom.production.min.js 176 KiB [built] [code generated]
│   modules by path ../../node_modules/.pnpm/react@17.0.1/node_modules/react/ 8.27 KiB
│     ../../node_modules/.pnpm/react@17.0.1/node_modules/react/index.js 189 bytes [built] [code generated]
│     ../../node_modules/.pnpm/react@17.0.1/node_modules/react/cjs/react.production.min.js 8.08 KiB [built] [code generated]
│   modules by path ../../node_modules/.pnpm/scheduler@0.20.1/node_modules/scheduler/ 6.86 KiB
│     ../../node_modules/.pnpm/scheduler@0.20.1/node_modules/scheduler/index.js 197 bytes [built] [code generated]
│     ../../node_modules/.pnpm/scheduler@0.20.1/node_modules/scheduler/cjs/scheduler.production.min.js 6.67 KiB [built] [code generated]
│   ../../node_modules/.pnpm/object-assign@4.1.1/node_modules/object-assign/index.js 1.77 KiB [built] [code generated]
│ ./src/index.js + 1 modules 287 bytes [built] [code generated]
│ webpack 5.24.2 compiled successfully in 808 ms
└─ Done in 2.1s
examples/typescript build$ npm run typecheck && webpack
│ > typescript@ typecheck esbuild-loader-examples/examples/typescript
│ > tsc --noEmit
│ asset main.js 558 bytes [compared for emit] [minimized] (name: main)
│ runtime modules 670 bytes 3 modules
│ ./src/index.ts 72 bytes [built] [code generated]
│ webpack 5.24.2 compiled successfully in 108 ms
└─ Done in 4.6s
```

### After
```
➜  esbuild-loader-examples git:(master) ✗ pnpm run build -r
Scope: all 5 workspace projects
examples/basic-setup build$ webpack
│ asset main.js 1.35 KiB [emitted] [minimized] (name: main)
│ ./src/index.js 2.68 KiB [built] [code generated]
│ webpack 5.24.2 compiled successfully in 202 ms
└─ Done in 1.1s
examples/next build$ next build
[13 lines collapsed]
│   ├ chunks/commons.65666e.js                                   2.83 kB
│   ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.15ed73.js  9.33 kB
│   ├ chunks/main.d8bb05.js                                      45.8 kB
│   ├ chunks/pages/_app.e164e4.js                                461 B
│   ├ chunks/webpack.a597c7.js                                   760 B
│   └ css/6e9ef204d6fd7ac61493.css                               194 B
│ λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
│ ○  (Static)  automatically rendered as static HTML (uses no initial props)
│ ●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
│    (ISR)     incremental static regeneration (uses revalidate in getStaticProps)
└─ Done in 4.1s
examples/react build$ webpack
[6 lines collapsed]
│     ../../node_modules/.pnpm/react-dom@17.0.1_react@17.0.1/node_modules/react-dom/cjs/react-dom.production.min.js 176 KiB [built] [code generated]
│   modules by path ../../node_modules/.pnpm/react@17.0.1/node_modules/react/ 8.27 KiB
│     ../../node_modules/.pnpm/react@17.0.1/node_modules/react/index.js 189 bytes [built] [code generated]
│     ../../node_modules/.pnpm/react@17.0.1/node_modules/react/cjs/react.production.min.js 8.08 KiB [built] [code generated]
│   modules by path ../../node_modules/.pnpm/scheduler@0.20.1/node_modules/scheduler/ 6.86 KiB
│     ../../node_modules/.pnpm/scheduler@0.20.1/node_modules/scheduler/index.js 197 bytes [built] [code generated]
│     ../../node_modules/.pnpm/scheduler@0.20.1/node_modules/scheduler/cjs/scheduler.production.min.js 6.67 KiB [built] [code generated]
│   ../../node_modules/.pnpm/object-assign@4.1.1/node_modules/object-assign/index.js 1.77 KiB [built] [code generated]
│ ./src/index.js + 1 modules 287 bytes [built] [code generated]
│ webpack 5.24.2 compiled successfully in 661 ms
└─ Done in 1.8s
examples/typescript build$ npm run typecheck && webpack
│ > typescript@ typecheck esbuild-loader-examples/examples/typescript
│ > tsc --noEmit
│ asset main.js 558 bytes [compared for emit] [minimized] (name: main)
│ runtime modules 670 bytes 3 modules
│ ./src/index.ts 72 bytes [built] [code generated]
│ webpack 5.24.2 compiled successfully in 136 ms
└─ Done in 4.9s
```