### PR TITLE
Fix for Next.js config

### DIFF
--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -11,9 +11,9 @@ function useEsbuildMinify(config, options) {
 
 function useEsbuildLoader(config, options) {
 	const { rules } = config.module;
-	const babelIndex = rules.findIndex(rule => rule.test.test('.js'));
+	const rule = rules.find(rule => rule.test.test('.js'));
 
-	rules[babelIndex].use = {
+	rule.use = {
 		loader: 'esbuild-loader',
 		options,
 	};

--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -1,23 +1,22 @@
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 
 function useEsbuildMinify(config, options) {
-	const terserIndex = config.optimization.minimizer.findIndex(minimizer => (minimizer.constructor.name === 'TerserPlugin'));
-	if (terserIndex > -1) {
-		config.optimization.minimizer.splice(
-			terserIndex,
-			1,
-			new ESBuildMinifyPlugin(options),
-		);
-	}
+	const { minimizer } = config.optimization;
+	const terserIndex = minimizer.findIndex(
+		minifier => minifier.constructor.name === 'TerserPlugin',
+	);
+	
+	minimizer.splice(terserIndex, 1, new ESBuildMinifyPlugin(options));
 }
 
 function useEsbuildLoader(config, options) {
-	const jsLoader = config.module.rules.find(rule => rule.test && rule.test.test('.js'));
+	const { rules } = config.module;
+	const babelIndex = rules.findIndex(rule => rule.test.test('.js'));
 
-	if (jsLoader) {
-		jsLoader.use.loader = 'esbuild-loader';
-		jsLoader.use.options = options;
-	}
+	rules[babelIndex].use = {
+		loader: 'esbuild-loader',
+		options,
+	};
 }
 
 module.exports = {
@@ -29,9 +28,8 @@ module.exports = {
 		);
 
 		useEsbuildMinify(config);
-
 		useEsbuildLoader(config, {
-			// Specify `tsx` if you're using TypeSCript
+			// Specify `tsx` if you're using TypeScript
 			loader: 'jsx',
 			target: 'es2017',
 		});


### PR DESCRIPTION
In regards to https://github.com/privatenumber/esbuild-loader/issues/84#issuecomment-867738885 just tried to use it and got an error, so I had to manually adapt it. (and "optimize" it in the process, the changes shouldn't be a problem)

Although from my testing it's usually around 30% slower compared to default config? Given I tried it on a boilerplate that barely has 2 pages, but still.